### PR TITLE
Replace custom lifetime logic with `std::unique_ptr`

### DIFF
--- a/include/fftw-cpp/basic_plan.h
+++ b/include/fftw-cpp/basic_plan.h
@@ -7,6 +7,21 @@
 
 namespace fftw {
 
+    template<size_t D, class Real, class Complex>
+    class plan_base {
+    protected:
+        using plan_t = detail::fftw_plan_t<Real>;
+        std::unique_ptr<std::remove_pointer_t<plan_t>, decltype(&fftw_destroy_plan)> plan;
+
+    public:
+        plan_base() noexcept: plan(nullptr, &fftw_destroy_plan) {}
+
+        explicit plan_base(plan_t ptr) noexcept: plan(ptr, &fftw_destroy_plan) {}
+
+        /// Returns the underlying FFTW plan.
+        plan_t c_plan() const { return plan.get(); }
+    };
+
     /// This concept checks that the layout is appropriate for this type of plan.
     /// By default, it is false
     template<typename Layout>
@@ -53,17 +68,16 @@ namespace fftw {
 
 
     template<size_t D, class Real, class Complex = std::complex<Real>>
-    class basic_plan {
+    class basic_plan : public plan_base<D, Real, Complex> {
     private:
-        using plan_t = detail::fftw_plan_t<Real>;
-        std::unique_ptr<std::remove_pointer_t<plan_t>, decltype(&fftw_destroy_plan)> plan;
-
+        using base = plan_base<D, Real, Complex>;
+        using plan_t = typename base::plan_t;
     public:
         using real_t = Real;
         using complex_t = Complex;
 
-        basic_plan() noexcept: plan(nullptr, &fftw_destroy_plan) {}
-        explicit basic_plan(plan_t ptr) noexcept: plan(ptr, &fftw_destroy_plan) {}
+        using base::plan_base;
+        using base::c_plan;
 
         /// Executes the plan with the buffers provided initially.
         void operator()() const;
@@ -75,10 +89,6 @@ namespace fftw {
         template<typename ViewIn, typename ViewOut>
         requires appropriate_views<D, Real, Complex, ViewIn, ViewOut>
         void operator()(ViewIn in, ViewOut out) const;
-
-        /// Returns the underlying FFTW plan.
-        plan_t c_plan() { return plan.get(); }
-        plan_t c_plan() const { return plan.get(); }
 
         /// \defgroup{planning utilities}
         template<typename BufferIn, typename BufferOut>
@@ -143,14 +153,14 @@ namespace fftw {
     template<typename BufferIn, typename BufferOut>
     requires appropriate_buffers<D, Real, Complex, BufferIn, BufferOut>
     void basic_plan<D, Real, Complex>::operator()(BufferIn &in, BufferOut &out) const {
-        fftw_execute_dft(plan, detail::unwrap<false, Real, Complex>(in), detail::unwrap<false, Real, Complex>(out));
+        fftw_execute_dft(c_plan(), detail::unwrap<false, Real, Complex>(in), detail::unwrap<false, Real, Complex>(out));
     }
 
     template<size_t D, class Real, class Complex>
     template<typename ViewIn, typename ViewOut>
     requires appropriate_views<D, Real, Complex, ViewIn, ViewOut>
     void basic_plan<D, Real, Complex>::operator()(ViewIn in, ViewOut out) const {
-        fftw_execute_dft(plan, detail::unwrap<false, Real, Complex>(in), detail::unwrap<false, Real, Complex>(out));
+        fftw_execute_dft(c_plan(), detail::unwrap<false, Real, Complex>(in), detail::unwrap<false, Real, Complex>(out));
     }
 
     template<size_t D, class Real, class Complex>
@@ -179,61 +189,40 @@ namespace fftw {
         return basic_plan{c_plan};
     }
 
-    template<size_t D, class Real, class Complex>
-    class base_plan {
-
-    };
-
     template<size_t D, class Real, class Complex = std::complex<Real>>
-    class basic_plan_r2c : public base_plan<D, Real, Complex> {
+    class basic_plan_r2c : public plan_base<D, Real, Complex> {
+    private:
+        using base = plan_base<D, Real, Complex>;
+        using plan_t = typename base::plan_t;
     public:
         using real_t = Real;
         using complex_t = Complex;
 
-        basic_plan_r2c() noexcept = default;
-
-        ~basic_plan_r2c();
-
-        /// Deleted copy constructor to disable copying
-        basic_plan_r2c(const basic_plan_r2c &) = delete;
-
-        basic_plan_r2c(basic_plan_r2c &&other) noexcept; ///< Move constructor
-        basic_plan_r2c &operator=(basic_plan_r2c &&other) noexcept; ///< Move assignment
-        void swap(basic_plan_r2c &other) noexcept;
+        using base::plan_base;
+        using base::c_plan;
 
         /// Executes the plan with the buffers provided initially.
         void operator()() const;
 
         template<typename ViewIn, typename ViewOut>
         void operator()(ViewIn in, ViewOut out) const;
-
-        /// Returns the underlying FFTW plan.
-        detail::fftw_plan_t<Real> unwrap() { return plan; }
 
         /// \defgroup{planning utilities}
         template<typename ViewIn, typename ViewOut>
         static auto dft(ViewIn in, ViewOut out, Flags flags) -> basic_plan_r2c;
-
-    private:
-        detail::fftw_plan_t<Real> plan{nullptr};
     };
 
     template<size_t D, class Real, class Complex = std::complex<Real>>
-    class basic_plan_c2r : public base_plan<D, Real, Complex> {
+    class basic_plan_c2r : public plan_base<D, Real, Complex> {
+    private:
+        using base = plan_base<D, Real, Complex>;
+        using plan_t = typename base::plan_t;
     public:
         using real_t = Real;
         using complex_t = Complex;
 
-        basic_plan_c2r() noexcept = default;
-
-        ~basic_plan_c2r();
-
-        /// Deleted copy constructor to disable copying
-        basic_plan_c2r(const basic_plan_c2r &) = delete;
-
-        basic_plan_c2r(basic_plan_c2r &&other) noexcept; ///< Move constructor
-        basic_plan_c2r &operator=(basic_plan_c2r &&other) noexcept; ///< Move assignment
-        void swap(basic_plan_c2r &other) noexcept;
+        using base::plan_base;
+        using base::c_plan;
 
         /// Executes the plan with the buffers provided initially.
         void operator()() const;
@@ -241,81 +230,33 @@ namespace fftw {
         template<typename ViewIn, typename ViewOut>
         void operator()(ViewIn in, ViewOut out) const;
 
-        /// Returns the underlying FFTW plan.
-        detail::fftw_plan_t<Real> unwrap() { return plan; }
-
         /// \defgroup{planning utilities}
         template<typename ViewIn, typename ViewOut>
         static auto dft(ViewIn in, ViewOut out, Flags flags) -> basic_plan_c2r;
-
-    private:
-        detail::fftw_plan_t<Real> plan{nullptr};
     };
 
     template<size_t D, class Real, class Complex>
-    basic_plan_r2c<D, Real, Complex>::~basic_plan_r2c() {
-        if (plan != nullptr) fftw_destroy_plan(plan);
-        plan = nullptr;
-    }
-
-    template<size_t D, class Real, class Complex>
-    void basic_plan_r2c<D, Real, Complex>::swap(basic_plan_r2c &other) noexcept {
-        std::swap(plan, other.plan);
-    }
-
-    template<size_t D, class Real, class Complex>
-    basic_plan_r2c<D, Real, Complex>::basic_plan_r2c(basic_plan_r2c &&other) noexcept {
-        other.swap(*this);
-    }
-
-    template<size_t D, class Real, class Complex>
-    basic_plan_r2c<D, Real, Complex> &basic_plan_r2c<D, Real, Complex>::operator=(basic_plan_r2c &&other) noexcept {
-        basic_plan_r2c(std::move(other)).swap(*this);
-        return *this;
-    }
-
-    template<size_t D, class Real, class Complex>
     void basic_plan_r2c<D, Real, Complex>::operator()() const {
-        fftw_execute(plan);
+        fftw_execute(c_plan());
     }
 
     template<size_t D, class Real, class Complex>
     template<typename ViewIn, typename ViewOut>
     void basic_plan_r2c<D, Real, Complex>::operator()(ViewIn in, ViewOut out) const {
-        fftw_execute_dft_r2c(plan, detail::unwrap<true, Real, Complex>(in), detail::unwrap<false, Real, Complex>(out));
-    }
-
-    template<size_t D, class Real, class Complex>
-    basic_plan_c2r<D, Real, Complex>::~basic_plan_c2r() {
-        if (plan != nullptr) fftw_destroy_plan(plan);
-        plan = nullptr;
-    }
-
-    template<size_t D, class Real, class Complex>
-    void basic_plan_c2r<D, Real, Complex>::swap(basic_plan_c2r &other) noexcept {
-        std::swap(plan, other.plan);
-    }
-
-    template<size_t D, class Real, class Complex>
-    basic_plan_c2r<D, Real, Complex>::basic_plan_c2r(basic_plan_c2r &&other) noexcept {
-        other.swap(*this);
-    }
-
-    template<size_t D, class Real, class Complex>
-    basic_plan_c2r<D, Real, Complex> &basic_plan_c2r<D, Real, Complex>::operator=(basic_plan_c2r &&other) noexcept {
-        basic_plan_c2r(std::move(other)).swap(*this);
-        return *this;
+        fftw_execute_dft_r2c(c_plan(), detail::unwrap<true, Real, Complex>(in),
+                             detail::unwrap<false, Real, Complex>(out));
     }
 
     template<size_t D, class Real, class Complex>
     void basic_plan_c2r<D, Real, Complex>::operator()() const {
-        fftw_execute(plan);
+        fftw_execute(c_plan());
     }
 
     template<size_t D, class Real, class Complex>
     template<typename ViewIn, typename ViewOut>
     void basic_plan_c2r<D, Real, Complex>::operator()(ViewIn in, ViewOut out) const {
-        fftw_execute_dft_c2r(plan, detail::unwrap<false, Real, Complex>(in), detail::unwrap<true, Real, Complex>(out));
+        fftw_execute_dft_c2r(c_plan(), detail::unwrap<false, Real, Complex>(in),
+                             detail::unwrap<true, Real, Complex>(out));
     }
 
     namespace detail {
@@ -395,7 +336,6 @@ namespace fftw {
 
         template<size_t D, class Real, class Complex>
         requires std::same_as<Real, double>
-
         auto plan_dft_r2c(auto in, auto out, Flags flags) {
             return fftw_plan_dft_r2c(D, dims_r2c<D>(in, out).data(), unwrap<true, Real, Complex>(in),
                                      unwrap<false, Real, Complex>(out),
@@ -404,7 +344,6 @@ namespace fftw {
 
         template<size_t D, class Real, class Complex>
         requires std::same_as<Real, double>
-
         auto plan_dft_c2r(auto in, auto out, Flags flags) {
             return fftw_plan_dft_c2r(D, dims_r2c<D>(out, in).data(), unwrap<false, Real, Complex>(in),
                                      unwrap<true, Real, Complex>(out),
@@ -417,18 +356,16 @@ namespace fftw {
     template<typename ViewIn, typename ViewOut>
     auto basic_plan_r2c<D, Real, Complex>::dft(ViewIn in, ViewOut out, fftw::Flags flags)
     -> basic_plan_r2c<D, Real, Complex> {
-        basic_plan_r2c plan1;
-        plan1.plan = detail::template plan_dft_r2c<D, Real, Complex>(in, out, flags);
-        return plan1;
+        auto c_plan = detail::template plan_dft_r2c<D, Real, Complex>(in, out, flags);
+        return basic_plan_r2c{c_plan};
     }
 
     template<size_t D, class Real, class Complex>
     template<typename ViewIn, typename ViewOut>
     auto basic_plan_c2r<D, Real, Complex>::dft(ViewIn in, ViewOut out, fftw::Flags flags)
     -> basic_plan_c2r<D, Real, Complex> {
-        basic_plan_c2r plan1;
-        plan1.plan = detail::template plan_dft_c2r<D, Real, Complex>(in, out, flags);
-        return plan1;
+        auto c_plan = detail::template plan_dft_c2r<D, Real, Complex>(in, out, flags);
+        return basic_plan_c2r{c_plan};
     }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ FetchContent_MakeAvailable(googletest)
 
 add_executable(fftw-cpp-tests
         test-1d-c2c.cpp
+        test-2d-r2c.cpp
 )
 
 target_link_libraries(fftw-cpp-tests fftw-cpp GTest::gmock_main)

--- a/test/test-2d-r2c.cpp
+++ b/test/test-2d-r2c.cpp
@@ -1,0 +1,40 @@
+#include "fftw-cpp/fftw-cpp.h"
+#include "util.hpp"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <numbers>
+#include <vector>
+
+TEST(Basic2dWrapperR2C, TwoWay) {
+    namespace stdex = std::experimental;
+
+    std::size_t N = 4, M = 6, NK = 3;
+    using d2 = stdex::dextents<std::size_t, 2u>;
+    fftw::basic_rmdbuffer<double, d2, std::complex<double>, stdex::layout_left> in{N, M}, out2{N, M};
+    fftw::basic_mdbuffer<double, d2, std::complex<double>, stdex::layout_left> out{NK, M};
+
+    auto p = fftw::plan_r2c<2u>::dft(in.to_mdspan(), out.to_mdspan(), fftw::Flags::ESTIMATE);
+    auto pInv = fftw::plan_c2r<2u>::dft(out.to_mdspan(), out2.to_mdspan(), fftw::Flags::ESTIMATE);
+
+    for (int j = 0; j < in.extent(0); ++j) {
+        for (int k = 0; k < in.extent(1); ++k) {
+            in(j, k) = std::cos(2.0 * std::numbers::pi * double((j + 1) * k) / (2.0 * double(in.size())));
+        }
+    }
+
+
+    p();
+    pInv();
+
+    for (int j = 0; j < out2.extent(0); ++j) {
+        for (int k = 0; k < out2.extent(1); ++k) {
+            out2(j, k) /= double(out2.size());
+        }
+    }
+
+    // TODO better matcher utils for mdspan
+    std::span out2_span{out2.data(), out2.size()};
+    std::span in_span{in.data(), in.size()};
+    EXPECT_THAT(out2_span, ElementsAreComplexNear(in_span));
+}

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -29,7 +29,7 @@ MATCHER_P(ElementsAreComplexNear, buf_expected, "values near " + ::testing::Prin
     return true;
 }
 
-auto ElementsAreComplexNear(const fftw::buffer &buf_expected) {
+auto inline ElementsAreComplexNear(const fftw::buffer &buf_expected) {
     std::vector<std::complex<double>> buf_expected_data(buf_expected.size());
     std::ranges::copy(buf_expected, buf_expected_data.begin());
 


### PR DESCRIPTION
To avoid custom move/copy constructors, assignment operators, and destructors, we utilize unique_ptr with a custom deleted to express move-only semantics.

While I was at it, I also:
- renamed the base plan to `plan_base`
- extracted common functionality from all types of basic plans
- added a basic r2c test
- did the same for `basic_buffer`